### PR TITLE
fix(lib/angular-scenario.js): Support manually bootstrapped apps

### DIFF
--- a/lib/angular-scenario.js
+++ b/lib/angular-scenario.js
@@ -10358,8 +10358,9 @@ function angularInit(element, bootstrap) {
   var elements = [element],
       appElement,
       module,
-      names = ['ng:app', 'ng-app', 'x-ng-app', 'data-ng-app'],
-      NG_APP_CLASS_REGEXP = /\sng[:\-]app(:\s*([\w\d_]+);?)?\s/;
+      names = ['ng:app', 'ng-app', 'x-ng-app', 'data-ng-app',
+        'karma:app', 'karma-app', 'x-karma-app', 'data-karma-app'],
+      NG_APP_CLASS_REGEXP = /\s(?:karma|ng)[:\-]app(:\s*([\w\d_]+);?)?\s/;
 
   function append(element) {
     element && elements.push(element);


### PR DESCRIPTION
Recognize element decorated with karma-app attribute (and various data-_/x-_/etc
flavors) or class name as the element where the angular app will be manually
bootstrapped. Allow karma to run when no element has been decorated with ng-app.

I believe this behavior is known:

https://groups.google.com/forum/#!msg/angular/d9-QYgSeib8/Ziy4kTvndsIJ

It seems that the recommended workaround is to do something like `angular.element(document).unbind('DOMContentLoaded');` right after loading the angular lib. This is not exactly a convenient/elegant workaround to say the least and I'd like to propose an alternative.
