### PR TITLE
Added code coverage handleling

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,5 +1,6 @@
 var registerResultListeners = function(model, tc) {
   var totalTests = 0, testsCompleted = 0;
+  var coverages = [];
 
   var createFailedSpecLog = function(spec) {
     var failedStep = findFailedStep(spec.steps);
@@ -35,8 +36,7 @@ var registerResultListeners = function(model, tc) {
       success: spec.status === 'success',
       skipped: false,
       time: spec.duration,
-      log: [],
-      coverage: window.document.getElementsByTagName('iframe')[0].contentWindow.__coverage__
+      log: []
     };
 
     if (spec.error) {
@@ -44,6 +44,7 @@ var registerResultListeners = function(model, tc) {
     }
 
     testsCompleted++;
+    coverages.push(window.document.getElementsByTagName('iframe')[0].contentWindow.__coverage__);
     tc.result(result);
   });
 
@@ -64,7 +65,7 @@ var registerResultListeners = function(model, tc) {
     }
 
     tc.complete({
-      coverage: window.document.getElementsByTagName('iframe')[0].contentWindow.__coverage__
+      coverage: coverages
     });
   });
 };


### PR DESCRIPTION
With this change, each e2e test code coverage obejct is taken from the
iframe and saved in an array. This array is then passed on to the
adapter, which uses istanbul to merge the coverage obejcts.
