### PR TITLE
Added code coverage

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -35,7 +35,8 @@ var registerResultListeners = function(model, tc) {
       success: spec.status === 'success',
       skipped: false,
       time: spec.duration,
-      log: []
+      log: [],
+      coverage: window.document.getElementsByTagName('iframe')[0].contentWindow.__coverage__
     };
 
     if (spec.error) {
@@ -62,9 +63,7 @@ var registerResultListeners = function(model, tc) {
       });
     }
 
-    tc.complete({
-      coverage: window.__coverage__
-    });
+    tc.complete();
   });
 };
 


### PR DESCRIPTION
Code coverage is now added - the coverage object is taken after each
spec end, from the iframe that run the test and is passed after each
spec end. All coverage objects are then merged and report is generated.
For this to work, the code has to have been previously instrumented with
Istanbul.
