### PR TITLE
Report step progress to Karma

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -26,6 +26,14 @@ var registerResultListeners = function(model, tc) {
     tc.info({total: totalTests});
   });
 
+  model.on('StepBegin', function(spec) {
+    tc.info({});
+  });
+
+  model.on('StepEnd', function(spec) {
+    tc.info({});
+  });
+
   model.on('SpecEnd', function(spec) {
     var iframe = window.document.getElementsByTagName('iframe')[0];
 

--- a/test/adapter.spec.js
+++ b/test/adapter.spec.js
@@ -125,5 +125,21 @@ describe('adapter angular-scenario', function() {
       model.emit('SpecEnd', failingSpec);
       expect(tc.result).toHaveBeenCalled();
     });
+
+    it('should report progress before every step', function() {
+      spyOn(tc, 'info');
+
+      model.emit('StepBegin', passingSpec);
+
+      expect(tc.info).toHaveBeenCalled();
+    });
+
+    it('should report progress after every step', function() {
+      spyOn(tc, 'info');
+
+      model.emit('StepEnd', passingSpec);
+
+      expect(tc.info).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Reporting progress to Karma for each step makes Karma less likely to believe that the browser is disconnected when a test with many steps is taking longer than usual.

In practice, this makes Karma's `browserNoActivityTimeout` limit the maximum allowed time for a single step (instead of a whole test) before considering the browser to be disconnected.

What are the chances that this will get merged and published any time soon? If they're slim, I'll likely publish my own fork on npm.