### PR TITLE
Use strict DI for $delegate and $browser

### DIFF
--- a/lib/angular-scenario.js
+++ b/lib/angular-scenario.js
@@ -26817,11 +26817,11 @@ angular.scenario.Application.prototype.navigateTo = function(url, loadFn, errorF
           // TODO(i): this doesn't disable javascript animations
           //          we don't need that for our tests, but it should be done
           $window.angular.resumeBootstrap([['$provide', function($provide) {
-            $provide.decorator('$sniffer', function($delegate) {
+            $provide.decorator('$sniffer', ['$delegate', function($delegate) {
               $delegate.transitions = false;
               $delegate.animations = false;
               return $delegate;
-            });
+            }]);
           }]]);
         }
 
@@ -26861,11 +26861,11 @@ angular.scenario.Application.prototype.executeAction = function(action) {
       return $injector;
     };
 
-    $injector.invoke(function($browser){
+    $injector.invoke(['$browser', function($browser){
       $browser.notifyWhenNoOutstandingRequests(function() {
         action.call(self, $window, $element);
       });
-    });
+    }]);
   });
 };
 


### PR DESCRIPTION
Without this change I ran into a error testing an app with strict DI activated:
Error: [$injector:strictdi] function($delegate) is not using explicit annotation and can not be invoked in strict mode
http://errors.angularjs.org/1.4.6/$injector/strictdi?p0=function(%24delegate)